### PR TITLE
Add a quick instruction to release app to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ electron .                           # start electron to test that everything wo
 ```
 
 After that you can follow [distribution guide for the electron.](https://github.com/atom/electron/blob/master/docs/tutorial/application-distribution.md)
+
+The easiest way to package an electron app is by using [electron-packager](https://github.com/maxogden/electron-packager):
+```shell
+electron-packager . HelloWorld --platform=darwin --arch=x64 --version=1.4.8
+```


### PR DESCRIPTION
A couple of days ago, I have spent many hours trying to figure out how to package an app from the link which is currently provided in README. I failed and almost give up.

Today, I found [Martin's sample project](https://github.com/martinklepsch/electron-and-clojurescript) which provides an example of single line command to run to package an app, and it just works. I think we should stick it here as well. Hopefully, it could prevent other people from having the same experience as me. 

I understand that there are many more detailed configurations in process of packaging an app, but I believe this example might be able to help direct people to the right thing to dig into.