### PR TITLE
Added support for Cider

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,8 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.10.238"]
                  [figwheel "0.5.15"]
+                 [figwheel-sidecar "0.5.18"]
+                 [cider/piggieback "0.4.0"]
                  [reagent "0.7.0"]
                  [ring/ring-core "1.6.3"]]
   :plugins [[lein-cljsbuild "1.1.7"]


### PR DESCRIPTION
I managed to add the support for Emacs Cider plugin by including those two dependencies. Now In Emacs you can open a source file, execute `M-x cider-jack-in-cljs RET figwheel RET` and it should start a figwheel REPL correctly inside Emacs.